### PR TITLE
May need Docker logout before build

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -15,7 +15,13 @@ you can work on the source code in your host environment.
 
    You might wish to explore and tweak Docker's preferences before
    using it.
-
+   
+   On first run, Docker may ask for account creation or log in.
+   LilyDev setup needs downloads from public repositories;
+   having an account logged in could interfere. So log out:
+   
+       docker logout
+       
 2. The provided `docker-compose.yaml` sets up a container with read-only
    access to the source directory and full access to a separate
    directory for build artifacts.  To tell Docker the host directories


### PR DESCRIPTION
I am new to Docker, and might not be understanding something here. I just installed Docker on Windows 10 Pro 1803 64-bit. My first effort at "docker-compose build" got me a message that said...

ERROR: Service 'lilypond-build' failed to build: Get https://registry-1.docker.io/v2/library/ubuntu/manifests/18.04: unauthorized: incorrect username or password

A web search advised me to log out my account from Docker, and the error was resolved. Maybe LilyDev's Docker instructions should mention this? Not sure which step would be best to include it.